### PR TITLE
Add graphical Morse decoder for tracked sine waves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,22 @@
 # Makefile for real-time Morse decoder
 # Requires SDL2 development libraries
 
-
 CC = gcc
 TARGET = morsed
 SRCS = main.c
+GUI_TARGET = morsed-gui
+GUI_SRCS = sample.c
 CFLAGS = -Wall -O2 `sdl2-config --cflags`
 LDFLAGS = `sdl2-config --libs` -lm
+GUI_LDFLAGS = `sdl2-config --libs` -lm -lfftw3 -lSDL2_ttf
 
-all: $(TARGET)
+all: $(TARGET) $(GUI_TARGET)
 
 $(TARGET): $(SRCS)
 	$(CC) $(CFLAGS) $(SRCS) -o $(TARGET) $(LDFLAGS)
 
+$(GUI_TARGET): $(GUI_SRCS)
+	$(CC) $(CFLAGS) $(GUI_SRCS) -o $(GUI_TARGET) $(GUI_LDFLAGS)
+
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGET) $(GUI_TARGET)

--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ make
 ```
 
 Each `<freq>` is the frequency in hertz to monitor. Press `Ctrl+C` to quit. A line containing `[space]` indicates a detected word gap.
+
+## Graphical interface
+
+`make` also builds `morsed-gui`, a graphical application based on the original sine wave detector. It automatically locks onto up to five sine waves and displays the decoded Morse code for each active channel.
+
+Run it with:
+
+```
+./morsed-gui
+```


### PR DESCRIPTION
## Summary
- Add Morse decoding structures and logic to `sample.c` so each tracked sine wave channel is decoded in real time and displayed in the GUI
- Capture and render decoded characters per channel and flush output when a signal disappears
- Update build system and README to include new `morsed-gui` graphical application

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a394a8425c8326af24b5e7fbead020