### PR TITLE
Add keyboard-controlled test tone for Morse decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ keyboard layout, the comma, keypad `.` or even the space bar can be used
 instead. This can be used as a simple Morse key to verify decoding without
 external audio equipment.
 
+The `morsed` window title includes the build date and time so you can confirm
+which binary version is running.
+
 The decoder assumes an initial speed of 15 words per minute to estimate
 the lengths of dits and dahs.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ make
 
 Each `<freq>` is the frequency in hertz to monitor. Press `Ctrl+C` to quit. A line containing `[space]` indicates a detected word gap.
 
+Press the `.` key to inject a test tone at the first specified frequency. This
+can be used as a simple Morse key to verify decoding without external audio
+equipment.
+
 The decoder assumes an initial speed of 15 words per minute to estimate
 the lengths of dits and dahs.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ make
 
 Each `<freq>` is the frequency in hertz to monitor. Press `Ctrl+C` to quit. A line containing `[space]` indicates a detected word gap.
 
-Press the `.` key to inject a test tone at the first specified frequency. This
-can be used as a simple Morse key to verify decoding without external audio
-equipment.
+Press the `.` key while the `morsed` window has focus to inject an audible test
+tone at the first specified frequency. This can be used as a simple Morse key to
+verify decoding without external audio equipment.
 
 The decoder assumes an initial speed of 15 words per minute to estimate
 the lengths of dits and dahs.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ make
 Each `<freq>` is the frequency in hertz to monitor. Press `Ctrl+C` to quit. A line containing `[space]` indicates a detected word gap.
 
 Press the `.` key while the `morsed` window has focus to inject an audible test
-tone at the first specified frequency. This can be used as a simple Morse key to
-verify decoding without external audio equipment.
+tone at the first specified frequency. If `.` does not trigger a tone on your
+keyboard layout, the comma, keypad `.` or even the space bar can be used
+instead. This can be used as a simple Morse key to verify decoding without
+external audio equipment.
 
 The decoder assumes an initial speed of 15 words per minute to estimate
 the lengths of dits and dahs.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Press the `.` key while the `morsed` window has focus to inject an audible test
 tone at the first specified frequency. If `.` does not trigger a tone on your
 keyboard layout, the comma, keypad `.` or even the space bar can be used
 instead. This can be used as a simple Morse key to verify decoding without
-external audio equipment.
+external audio equipment. A log message is printed whenever the period key is
+pressed so you can confirm it is being detected.
 
 The `morsed` window title includes the build date and time so you can confirm
 which binary version is running.

--- a/main.c
+++ b/main.c
@@ -155,6 +155,20 @@ static void handle_sigint(int sig)
     keep_running = 0;
 }
 
+static bool is_test_key(SDL_Scancode sc, SDL_Keycode sym)
+{
+    return sc == SDL_SCANCODE_PERIOD || sc == SDL_SCANCODE_COMMA ||
+           sc == SDL_SCANCODE_KP_PERIOD || sc == SDL_SCANCODE_SPACE ||
+           sym == SDLK_PERIOD || sym == SDLK_COMMA ||
+           sym == SDLK_KP_PERIOD || sym == SDLK_SPACE;
+}
+
+static bool is_period_key(SDL_Scancode sc, SDL_Keycode sym)
+{
+    return sc == SDL_SCANCODE_PERIOD || sym == SDLK_PERIOD ||
+           sc == SDL_SCANCODE_KP_PERIOD || sym == SDLK_KP_PERIOD;
+}
+
 /* -------------------------------- main --------------------------------- */
 int main(int argc, char **argv)
 {
@@ -184,7 +198,8 @@ int main(int argc, char **argv)
     }
 
     const char *build_timestamp = __DATE__ " " __TIME__;
-    printf("morsed build: %s\n", build_timestamp);
+    SDL_LogSetAllPriority(SDL_LOG_PRIORITY_INFO);
+    SDL_Log("morsed build: %s", build_timestamp);
 
     /* create small window to receive keyboard events */
     char title[128];
@@ -197,6 +212,7 @@ int main(int argc, char **argv)
         free(channels);
         return 1;
     }
+    SDL_ShowWindow(win);
 
     SDL_AudioSpec want, have;
     SDL_zero(want);
@@ -255,14 +271,18 @@ int main(int argc, char **argv)
                 keep_running = 0;
             } else if (e.type == SDL_KEYDOWN) {
                 SDL_Scancode sc = e.key.keysym.scancode;
-                if (sc == SDL_SCANCODE_PERIOD || sc == SDL_SCANCODE_COMMA ||
-                    sc == SDL_SCANCODE_KP_PERIOD || sc == SDL_SCANCODE_SPACE) {
+                SDL_Keycode sym = e.key.keysym.sym;
+                if (is_test_key(sc, sym)) {
+                    if (is_period_key(sc, sym))
+                        SDL_Log("Period key pressed");
                     key_down = true;
                 }
             } else if (e.type == SDL_KEYUP) {
                 SDL_Scancode sc = e.key.keysym.scancode;
-                if (sc == SDL_SCANCODE_PERIOD || sc == SDL_SCANCODE_COMMA ||
-                    sc == SDL_SCANCODE_KP_PERIOD || sc == SDL_SCANCODE_SPACE) {
+                SDL_Keycode sym = e.key.keysym.sym;
+                if (is_test_key(sc, sym)) {
+                    if (is_period_key(sc, sym))
+                        SDL_Log("Period key released");
                     key_down = false;
                 }
             }

--- a/main.c
+++ b/main.c
@@ -183,8 +183,13 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    const char *build_timestamp = __DATE__ " " __TIME__;
+    printf("morsed build: %s\n", build_timestamp);
+
     /* create small window to receive keyboard events */
-    SDL_Window *win = SDL_CreateWindow("morsed", SDL_WINDOWPOS_UNDEFINED,
+    char title[128];
+    snprintf(title, sizeof(title), "morsed - %s", build_timestamp);
+    SDL_Window *win = SDL_CreateWindow(title, SDL_WINDOWPOS_UNDEFINED,
                                       SDL_WINDOWPOS_UNDEFINED, 200, 100, 0);
     if (!win) {
         fprintf(stderr, "SDL_CreateWindow failed: %s\n", SDL_GetError());
@@ -249,15 +254,15 @@ int main(int argc, char **argv)
                 (e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_ESCAPE)) {
                 keep_running = 0;
             } else if (e.type == SDL_KEYDOWN) {
-                SDL_Keycode k = e.key.keysym.sym;
-                if (k == SDLK_PERIOD || k == SDLK_COMMA ||
-                    k == SDLK_KP_PERIOD || k == SDLK_SPACE) {
+                SDL_Scancode sc = e.key.keysym.scancode;
+                if (sc == SDL_SCANCODE_PERIOD || sc == SDL_SCANCODE_COMMA ||
+                    sc == SDL_SCANCODE_KP_PERIOD || sc == SDL_SCANCODE_SPACE) {
                     key_down = true;
                 }
             } else if (e.type == SDL_KEYUP) {
-                SDL_Keycode k = e.key.keysym.sym;
-                if (k == SDLK_PERIOD || k == SDLK_COMMA ||
-                    k == SDLK_KP_PERIOD || k == SDLK_SPACE) {
+                SDL_Scancode sc = e.key.keysym.scancode;
+                if (sc == SDL_SCANCODE_PERIOD || sc == SDL_SCANCODE_COMMA ||
+                    sc == SDL_SCANCODE_KP_PERIOD || sc == SDL_SCANCODE_SPACE) {
                     key_down = false;
                 }
             }

--- a/main.c
+++ b/main.c
@@ -245,12 +245,21 @@ int main(int argc, char **argv)
     while (keep_running) {
         SDL_Event e;
         while (SDL_PollEvent(&e)) {
-            if (e.type == SDL_QUIT) {
+            if (e.type == SDL_QUIT ||
+                (e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_ESCAPE)) {
                 keep_running = 0;
-            } else if (e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_PERIOD) {
-                key_down = true;
-            } else if (e.type == SDL_KEYUP && e.key.keysym.sym == SDLK_PERIOD) {
-                key_down = false;
+            } else if (e.type == SDL_KEYDOWN) {
+                SDL_Keycode k = e.key.keysym.sym;
+                if (k == SDLK_PERIOD || k == SDLK_COMMA ||
+                    k == SDLK_KP_PERIOD || k == SDLK_SPACE) {
+                    key_down = true;
+                }
+            } else if (e.type == SDL_KEYUP) {
+                SDL_Keycode k = e.key.keysym.sym;
+                if (k == SDLK_PERIOD || k == SDLK_COMMA ||
+                    k == SDLK_KP_PERIOD || k == SDLK_SPACE) {
+                    key_down = false;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- allow `.` key to inject a test tone at the first configured frequency
- document the keyboard test tone capability in README

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a63d22e92c8326a63ef628332ac944