### PR TITLE
Use space bar for test tone and add version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ make
 
 Each `<freq>` is the frequency in hertz to monitor. Press `Ctrl+C` to quit. A line containing `[space]` indicates a detected word gap.
 
-Press the `.` key while the `morsed` window has focus to inject an audible test
-tone at the first specified frequency. If `.` does not trigger a tone on your
-keyboard layout, the comma, keypad `.` or even the space bar can be used
-instead. This can be used as a simple Morse key to verify decoding without
-external audio equipment. A log message is printed whenever the period key is
-pressed so you can confirm it is being detected.
+Press the space bar while the `morsed` window has focus to inject an audible test
+tone at the first specified frequency. This can be used as a simple Morse key to
+verify decoding without external audio equipment. A log message is printed
+whenever the space bar is pressed so you can confirm it is being detected.
+
+Run `./morsed -v` to print the build version based on the repository timestamp.
 
 The `morsed` window title includes the build date and time so you can confirm
 which binary version is running.

--- a/main.c
+++ b/main.c
@@ -7,6 +7,8 @@
 #include <signal.h>
 #include <SDL2/SDL.h>
 
+#define MORSED_VERSION "20250820.222916"
+
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
@@ -157,21 +159,16 @@ static void handle_sigint(int sig)
 
 static bool is_test_key(SDL_Scancode sc, SDL_Keycode sym)
 {
-    return sc == SDL_SCANCODE_PERIOD || sc == SDL_SCANCODE_COMMA ||
-           sc == SDL_SCANCODE_KP_PERIOD || sc == SDL_SCANCODE_SPACE ||
-           sym == SDLK_PERIOD || sym == SDLK_COMMA ||
-           sym == SDLK_KP_PERIOD || sym == SDLK_SPACE;
-}
-
-static bool is_period_key(SDL_Scancode sc, SDL_Keycode sym)
-{
-    return sc == SDL_SCANCODE_PERIOD || sym == SDLK_PERIOD ||
-           sc == SDL_SCANCODE_KP_PERIOD || sym == SDLK_KP_PERIOD;
+    return sc == SDL_SCANCODE_SPACE || sym == SDLK_SPACE;
 }
 
 /* -------------------------------- main --------------------------------- */
 int main(int argc, char **argv)
 {
+    if (argc == 2 && strcmp(argv[1], "-v") == 0) {
+        printf("morsed %s\n", MORSED_VERSION);
+        return 0;
+    }
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <freq> [<freq> ...]\n", argv[0]);
         return 1;
@@ -273,16 +270,14 @@ int main(int argc, char **argv)
                 SDL_Scancode sc = e.key.keysym.scancode;
                 SDL_Keycode sym = e.key.keysym.sym;
                 if (is_test_key(sc, sym)) {
-                    if (is_period_key(sc, sym))
-                        SDL_Log("Period key pressed");
+                    SDL_Log("Space key pressed");
                     key_down = true;
                 }
             } else if (e.type == SDL_KEYUP) {
                 SDL_Scancode sc = e.key.keysym.scancode;
                 SDL_Keycode sym = e.key.keysym.sym;
                 if (is_test_key(sc, sym)) {
-                    if (is_period_key(sc, sym))
-                        SDL_Log("Period key released");
+                    SDL_Log("Space key released");
                     key_down = false;
                 }
             }


### PR DESCRIPTION
## Summary
- Log and trigger the test tone when the space bar is pressed instead of the period key
- Add `-v` flag to print a build timestamp version
- Document space bar test key and version flag in README

## Testing
- `make`
- `./morsed -v`


------
https://chatgpt.com/codex/tasks/task_e_68a64b5c2fd883268b449c27ff01754c